### PR TITLE
Issue #18 lower compute capability requirement.

### DIFF
--- a/2D_Stage/webui.py
+++ b/2D_Stage/webui.py
@@ -43,6 +43,24 @@ from huggingface_hub import hf_hub_download, list_repo_files
 repo_id = "zjpshadow/CharacterGen"
 all_files = list_repo_files(repo_id, revision="main")
 
+#7-23-2024 Changed to allow GPU with compute < 8
+device_capability = -1
+
+#bfloat Support is typically 8 or higher.
+def check_bfloat16_support():
+   # Check if bfloat16 is supported
+   device_capability = torch.cuda.get_device_capability()
+
+   if device_capability[0] >= 8:
+      print("CUDA device capability is above 8, using bfloat16.")
+      return torch.bfloat16
+   else:
+      print("CUDA device capability is below 8, using float 32.")
+      return torch.float32
+
+#7-23-2024 Changed to allow GPU with compute < 8
+data_type_float = check_bfloat16_support()
+
 for file in all_files:
     if os.path.exists("../" + file):
         continue
@@ -191,7 +209,7 @@ class Inference_API:
 
         # (B*Nv, 3, H, W)
         B = 1
-        weight_dtype = torch.bfloat16
+        weight_dtype =  data_type_float #7-23-2024 Changed to allow GPU with compute < 8
         imgs_in = process_image(input_image, totensor)
         imgs_in = rearrange(imgs_in.unsqueeze(0).unsqueeze(0), "B Nv C H W -> (B Nv) C H W")
                 

--- a/webui.py
+++ b/webui.py
@@ -52,6 +52,24 @@ import pymeshlab
 
 from huggingface_hub import hf_hub_download, list_repo_files
 
+#7-23-2024 Changed to allow GPU with compute < 8
+device_capability = -1
+
+#bfloat Support is typically 8 or higher.
+def check_bfloat16_support():
+   # Check if bfloat16 is supported
+   device_capability = torch.cuda.get_device_capability()
+
+   if device_capability[0] >= 8:
+      print("CUDA device capability is above 8, using bfloat16.")
+      return torch.bfloat16
+   else:
+      print("CUDA device capability is below 8, using float 32.")
+      return torch.float32
+
+#7-23-2024 Changed to allow GPU with compute < 8
+data_type_float = check_bfloat16_support()
+
 repo_id = "zjpshadow/CharacterGen"
 all_files = list_repo_files(repo_id, revision="main")
 
@@ -248,7 +266,7 @@ class Inference2D_API:
 
         # (B*Nv, 3, H, W)
         B = 1
-        weight_dtype = torch.bfloat16
+        weight_dtype =  data_type_float #7-23-2024 Changed to allow GPU with compute < 8
         imgs_in = process_image(input_image, totensor)
         imgs_in = rearrange(imgs_in.unsqueeze(0).unsqueeze(0), "B Nv C H W -> (B Nv) C H W")
                 
@@ -445,7 +463,7 @@ def main(
             inputs=[img_input0, img_input1, img_input2, img_input3, back_proj, smooth_iter],
             outputs=[output_dir, output_model_obj, output_model_glb]
         )
-    demo.launch(server_name="0.0.0.0")
+    demo.launch(server_name="0.0.0.0", share=True)
 
 if __name__ == "__main__":
     main()

--- a/webui.py
+++ b/webui.py
@@ -463,7 +463,7 @@ def main(
             inputs=[img_input0, img_input1, img_input2, img_input3, back_proj, smooth_iter],
             outputs=[output_dir, output_model_obj, output_model_glb]
         )
-    demo.launch(server_name="0.0.0.0", share=True)
+    demo.launch(server_name="0.0.0.0")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adds changes for GPUs with compute capability lower than 8 to use float32 rather than bfloat16.

There is no reliable way to check bfloat16 support, so just checking the capability score is good enough.